### PR TITLE
Update conanfile.txt

### DIFF
--- a/FallingSandSurvival/conanfile.txt
+++ b/FallingSandSurvival/conanfile.txt
@@ -1,7 +1,7 @@
 [requires]
 zlib/1.2.11
 libpng/1.6.37
-sdl2/2.0.12@bincrafters/stable
+sdl2/2.0.9@bincrafters/stable
 sdl2_ttf/2.0.15@bincrafters/stable
 sdl2_image/2.0.5@bincrafters/stable
 sdl_gpu/20201002@sdl_gpu/20201002


### PR DESCRIPTION
Because the package versions won't work otherwise.
cmake was complaining, and then failing because:
sdl2_ttf/2.0.15 needs sdl2/2.0.9, not sdl2/2.0.12.
This creates a trail of dependency issues, which leads to a failure.